### PR TITLE
sklearn compatible attributes

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,7 +10,7 @@ jobs:
         with:
           options: "--check --verbose"
           src: "."
-          version: 22.1.0
+          version: "22.1.0"
 
   test:
     name: Pytest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,6 +10,7 @@ jobs:
         with:
           options: "--check --verbose"
           src: "."
+          version: 22.1.0
 
   test:
     name: Pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: stable
     hooks:
     - id: black
       language_version: python3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.1.0
     hooks:
     - id: black
       language_version: python3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.5.6 (2022-02-21)
 ### Added
 - Trivial `inverse_transform` method that returns the input to `TruncateTransformer`, `TargetOutlierCorrectionTransformer`, and `TargetStructuralBreakCorrectionTransformer`. This addition allows using these transformers in `sklearn.compose.TransformedTargetRegressor` as `tranformer` argument for trivial inverse transform of pipeline predictions.  
+### Changed
+- Expose fitted attributes with trailing underscore: `x_train_`, `y_train_`, `fit_results_`.
+- Expose model parameters, e.g. `endog_transform` and `exog_transform` in `H andCraftedLinearModel`.
 
 ## 0.5.5 (2022-02-18)
 ### Changed

--- a/src/hcl_model/model_base.py
+++ b/src/hcl_model/model_base.py
@@ -19,11 +19,6 @@ class ModelBase(ABC):
     lbl_resid_kurtosis = "error_kurtosis"
     lbl_params = "parameters"
 
-    def __init__(self) -> None:
-        self._fit_results = None
-        self._y_train = None
-        self._x_train = None
-
     def fit(self, X: Optional[pd.DataFrame], y: Union[pd.Series, np.ndarray], **kwargs):
         """
         Fit the model using some provided training data.
@@ -33,7 +28,7 @@ class ModelBase(ABC):
             In case of np.ndarray its index is inherited from `X`.
             In case of np.ndarray and if `X` is `None`, then `TypeError` is risen.
         """
-        self._x_train, self._y_train = check_X_y(X=X, y=y)
+        self.x_train_, self.y_train_ = check_X_y(X=X, y=y)
         self._fit(**kwargs)
         return self
 
@@ -156,14 +151,14 @@ class ModelBase(ABC):
 
         :return: Error as a float in percent.
         """
-        return ((self._y_train - self._get_fitted_values()) / self._y_train).abs().mean() * 100
+        return ((self.y_train_ - self._get_fitted_values()) / self.y_train_).abs().mean() * 100
 
     def _get_rsquared(self) -> float:
         """Mean absolute percentage error on in-sample.
 
         :return: Error as a float in percent.
         """
-        return np.corrcoef(self._get_fitted_values(), self._y_train.values)[0, 1] ** 2
+        return np.corrcoef(self._get_fitted_values(), self.y_train_.values)[0, 1] ** 2
 
     def _get_residual_moment(self, degree: int = 1, center_first: bool = False) -> float:
         """Get residual moment.
@@ -196,26 +191,26 @@ class ModelBase(ABC):
         :param exog: exogenous data
         :raise RuntimeError:
         """
-        x_train_and_test = pd.concat([self._x_train, exog]) if exog is not None else self._x_train
+        x_train_and_test = pd.concat([self.x_train_, exog]) if exog is not None else self.x_train_
         if x_train_and_test is not None and x_train_and_test.shape[0] < nobs + num_steps:
             raise RuntimeError("Provided exogenous data does not cover the whole prediction horizon!")
 
     def _get_endog_name(self) -> str:
-        return self._y_train.name
+        return self.y_train_.name
 
     def _get_index_name(self) -> str:
-        return self._y_train.index.name
+        return self.y_train_.index.name
 
     @property
     def _nobs(self) -> int:
-        return self._y_train.shape[0]
+        return self.y_train_.shape[0]
 
     def get_parameters(self) -> pd.Series:
         """Get model parameters.
 
         :return: A series of model parameters.
         """
-        return self._fit_results.params
+        return self.fit_results_.params
 
     @staticmethod
     def get_quantile_names(quantile_levels: List[float]) -> List[str]:

--- a/src/hcl_model/model_base.py
+++ b/src/hcl_model/model_base.py
@@ -34,7 +34,7 @@ class ModelBase(ABC):
 
     @abstractmethod
     def _fit(self, **kwargs) -> None:
-        pass
+        """Core fit method."""
 
     def predict(
         self,
@@ -83,7 +83,7 @@ class ModelBase(ABC):
     def _predict(
         self, num_steps: int, X: pd.DataFrame = None, quantile_levels: List[float] = None, **kwargs
     ) -> pd.DataFrame:
-        pass
+        """Core predict method."""
 
     def simulate(self, num_steps: int, num_simulations: int, X: pd.DataFrame = None, **kwargs) -> pd.DataFrame:
         """
@@ -99,13 +99,13 @@ class ModelBase(ABC):
 
     @abstractmethod
     def _simulate(self, num_steps: int, num_simulations: int, **kwargs) -> pd.DataFrame:
-        pass
+        """Core simulate method."""
 
     @abstractmethod
     def _compute_prediction_quantiles(
         self, num_steps: int, num_simulations: int = None, quantile_levels: List[float] = None, X: pd.DataFrame = None
     ) -> pd.DataFrame:
-        pass
+        """Compute prediction quantiles."""
 
     def summary(self) -> pd.Series:
         """A summary of in-sample model performance KPIs.
@@ -218,4 +218,4 @@ class ModelBase(ABC):
 
     @abstractmethod
     def _add_trend(self, df: pd.DataFrame) -> pd.DataFrame:
-        pass
+        """Add trend."""

--- a/src/hcl_model/model_hcl_generic.py
+++ b/src/hcl_model/model_hcl_generic.py
@@ -109,7 +109,7 @@ class HandCraftedLinearModel(ModelBase):
         beta_simulated = pd.DataFrame(beta_simulated, columns=self.fit_results_.params.index)
         # simulate innovations for the right hand side of the model
         innovation = np.random.normal(
-            loc=0, scale=self.fit_results_.mse_resid ** 0.5, size=(num_steps, num_simulations)
+            loc=0, scale=self.fit_results_.mse_resid**0.5, size=(num_steps, num_simulations)
         )
 
         # stack observed endogenous series and empty container for future simulations

--- a/src/hcl_model/model_hcl_generic.py
+++ b/src/hcl_model/model_hcl_generic.py
@@ -63,14 +63,13 @@ class HandCraftedLinearModel(ModelBase):
     lbl_original_exog = "original_exog"
 
     def __init__(self, endog_transform: Dict[str, Callable] = None, exog_transform: Dict[str, Callable] = None) -> None:
-        super().__init__()
-        self._endog_transform = self._init_transform(name=self.lbl_original_endog, transform=endog_transform)
-        self._exog_transform = self._init_transform(name=self.lbl_original_exog, transform=exog_transform)
+        self.endog_transform = self._init_transform(name=self.lbl_original_endog, transform=endog_transform)
+        self.exog_transform = self._init_transform(name=self.lbl_original_exog, transform=exog_transform)
 
     def _fit(self, weights: Union[Sequence, float] = 1.0) -> None:
-        transformed = self._transform_all_data(endog=self._y_train, exog=self._x_train)
+        transformed = self._transform_all_data(endog=self.y_train_, exog=self.x_train_)
         rhs_vars = self._convert_transformed_dict_to_frame(transformed=transformed)
-        self._fit_results = WLS(endog=self._y_train, exog=rhs_vars, weights=weights, missing="drop").fit()
+        self.fit_results_ = WLS(endog=self.y_train_, exog=rhs_vars, weights=weights, missing="drop").fit()
 
     def _predict(
         self,
@@ -81,9 +80,9 @@ class HandCraftedLinearModel(ModelBase):
         num_simulations: int = None,
     ) -> pd.DataFrame:
         endog_updated = pd.concat(
-            [self._y_train, pd.Series(np.empty(num_steps), name=self._get_endog_name(), index=X.index)]
+            [self.y_train_, pd.Series(np.empty(num_steps), name=self._get_endog_name(), index=X.index)]
         )
-        x_train_and_test = pd.concat([self._x_train, X])
+        x_train_and_test = pd.concat([self.x_train_, X])
         for j in range(num_steps):
             transformed = self._transform_all_data(
                 endog=endog_updated[: self._nobs + j + 1], exog=x_train_and_test.iloc[: self._nobs + j + 1]
@@ -91,7 +90,7 @@ class HandCraftedLinearModel(ModelBase):
             rhs_vars = self._convert_transformed_dict_to_frame(transformed=transformed).iloc[-1, :]
             endog_updated.iloc[self._nobs + j] = np.dot(rhs_vars, self.get_parameters())
 
-        return endog_updated.iloc[self._nobs :].to_frame().rename_axis(index=self._y_train.index.name)
+        return endog_updated.iloc[self._nobs :].to_frame().rename_axis(index=self.y_train_.index.name)
 
     def _simulate(self, num_steps: int, num_simulations: int, X: pd.DataFrame = None, **kwargs) -> pd.DataFrame:
         num_params = self.get_parameters().shape[0]
@@ -103,19 +102,19 @@ class HandCraftedLinearModel(ModelBase):
         beta_simulated = (
             np.dot(
                 np.random.normal(loc=0, scale=1, size=(num_simulations, num_params)),
-                np.linalg.cholesky(self._fit_results.cov_params()).T,
+                np.linalg.cholesky(self.fit_results_.cov_params()).T,
             )
             + self.get_parameters().values
         )
-        beta_simulated = pd.DataFrame(beta_simulated, columns=self._fit_results.params.index)
+        beta_simulated = pd.DataFrame(beta_simulated, columns=self.fit_results_.params.index)
         # simulate innovations for the right hand side of the model
         innovation = np.random.normal(
-            loc=0, scale=self._fit_results.mse_resid**0.5, size=(num_steps, num_simulations)
+            loc=0, scale=self.fit_results_.mse_resid ** 0.5, size=(num_steps, num_simulations)
         )
 
         # stack observed endogenous series and empty container for future simulations
         # Series of length (nobs + num_steps)
-        endog_updated = pd.concat([self._y_train, pd.Series(np.empty(num_steps))], axis=0, ignore_index=True)
+        endog_updated = pd.concat([self.y_train_, pd.Series(np.empty(num_steps))], axis=0, ignore_index=True)
         # DataFrame (nobs + num_steps) x num_simulations
         endog_updated = pd.concat([endog_updated] * num_simulations, axis=1)
 
@@ -127,7 +126,7 @@ class HandCraftedLinearModel(ModelBase):
             for key, val in transformed_endog.items():
                 temp += val.iloc[-1, :] * beta_simulated[key]
 
-            transformed_exog = self._transform_all_data(exog=pd.concat([self._x_train, X]).iloc[: self._nobs + j + 1])
+            transformed_exog = self._transform_all_data(exog=pd.concat([self.x_train_, X]).iloc[: self._nobs + j + 1])
             exog_df = self._convert_transformed_dict_to_frame(transformed=transformed_exog)
             for key in exog_df.columns:
                 temp += exog_df[key].iloc[-1] * beta_simulated[key]
@@ -147,16 +146,16 @@ class HandCraftedLinearModel(ModelBase):
         return quantiles
 
     def _get_rsquared(self) -> float:
-        return self._fit_results.rsquared
+        return self.fit_results_.rsquared
 
     def _get_aic(self) -> float:
-        return self._fit_results.aic
+        return self.fit_results_.aic
 
     def _get_fitted_values(self) -> pd.Series:
-        return self._fit_results.fittedvalues
+        return self.fit_results_.fittedvalues
 
     def _get_residuals(self) -> pd.Series:
-        return self._fit_results.resid
+        return self.fit_results_.resid
 
     @staticmethod
     def _transform_data(
@@ -180,8 +179,8 @@ class HandCraftedLinearModel(ModelBase):
         :return: dictionary {f(Y_{t,L}), g(X_t)} of transformed endogenous and exogenous.
         Original endogenous variable is dropped from the dictionary to avoid using it as a right-hand-side variable.
         """
-        transformed_endog = self._transform_data(data=endog, transform=self._endog_transform)
-        transformed_exog = self._transform_data(data=exog, transform=self._exog_transform)
+        transformed_endog = self._transform_data(data=endog, transform=self.endog_transform)
+        transformed_exog = self._transform_data(data=exog, transform=self.exog_transform)
         transformed = {**transformed_endog, **transformed_exog}
         transformed.pop(self.lbl_original_endog, None)
         return transformed

--- a/src/hcl_model/model_sarimax.py
+++ b/src/hcl_model/model_sarimax.py
@@ -27,85 +27,83 @@ class SARIMAXModel(ModelBase):
         trend: str = "c",
         enforce_stationarity: bool = True,
     ) -> None:
-        super().__init__()
-        self._order = order
-        self._seasonal_order = seasonal_order
-        self._trend = trend
-        self._enforce_stationarity = enforce_stationarity
-        self._trend_fit = None
+        self.order = order
+        self.seasonal_order = seasonal_order
+        self.trend = trend
+        self.enforce_stationarity = enforce_stationarity
 
     def _fit(self, **kwargs) -> None:
-        self._y_train = self._remove_trend(self._y_train)
-        self._fit_results = SARIMAX(
-            self._y_train,
-            exog=self._x_train,
-            order=self._order,
-            seasonal_order=self._seasonal_order,
-            enforce_stationarity=self._enforce_stationarity,
+        self.y_train_ = self._remove_trend(self.y_train_)
+        self.fit_results_ = SARIMAX(
+            self.y_train_,
+            exog=self.x_train_,
+            order=self.order,
+            seasonal_order=self.seasonal_order,
+            enforce_stationarity=self.enforce_stationarity,
         ).fit(disp=False)
 
     def _predict(
         self, num_steps: int, X: pd.DataFrame = None, quantile_levels: List[float] = None, num_simulations: int = None
     ) -> pd.DataFrame:
         return (
-            self._fit_results.get_forecast(steps=num_steps, exog=X)
+            self.fit_results_.get_forecast(steps=num_steps, exog=X)
             .predicted_mean.rename(self._get_endog_name())
             .to_frame()
-            .rename_axis(index=self._y_train.index.name)
+            .rename_axis(index=self.y_train_.index.name)
         )
 
     def _simulate(self, num_steps: int, num_simulations: int, X: pd.DataFrame = None, **kwargs) -> pd.DataFrame:
-        self._y_train = self._remove_trend(self._y_train)
+        self.y_train_ = self._remove_trend(self.y_train_)
         sim_model = SARIMAX(
             pd.Series(index=X.index, dtype=float),
             exog=X,
-            order=self._order,
-            seasonal_order=self._seasonal_order,
-            enforce_stationarity=self._enforce_stationarity,
+            order=self.order,
+            seasonal_order=self.seasonal_order,
+            enforce_stationarity=self.enforce_stationarity,
         )
-        sim_model = sim_model.filter(params=self._fit_results.params)
+        sim_model = sim_model.filter(params=self.fit_results_.params)
         # TODO: check simulation output for different model. I am not sure it is correct without initial_sate.
         return pd.DataFrame({i: sim_model.simulate(num_steps) for i in range(num_simulations)})
 
     def _get_aic(self) -> float:
-        return self._fit_results.aic
+        return self.fit_results_.aic
 
     def _get_fitted_values(self) -> pd.Series:
-        return self._fit_results.fittedvalues
+        return self.fit_results_.fittedvalues
 
     def _get_residuals(self) -> pd.Series:
-        return self._fit_results.resid
+        return self.fit_results_.resid
 
     def _compute_prediction_quantiles(
         self, num_steps: int, quantile_levels: List[float] = None, X: pd.DataFrame = None, **kwargs
     ) -> pd.DataFrame:
-        forecast = self._fit_results.get_forecast(steps=num_steps, exog=X)
+        forecast = self.fit_results_.get_forecast(steps=num_steps, exog=X)
         out = dict()
         for alpha, q_name in zip(quantile_levels, self.get_quantile_names(quantile_levels)):
             if alpha < 50:
                 out[q_name] = forecast.conf_int(alpha=2 * alpha / 100).iloc[:, 0]
             else:
                 out[q_name] = forecast.conf_int(alpha=2 * (100 - alpha) / 100).iloc[:, 1]
-        return pd.DataFrame(out).rename_axis(index=self._y_train.index.name)
+        return pd.DataFrame(out).rename_axis(index=self.y_train_.index.name)
 
     def _remove_trend(self, endog: pd.Series) -> pd.Series:
-        if self._trend == "n":
+        if self.trend == "n":
             return endog
         else:
             name = endog.name
-            trend = add_trend(self._y_train, trend=self._trend, prepend=False)
-            self._trend_fit = OLS(endog, trend.iloc[:, 1:]).fit()
-            endog -= self._trend_fit.fittedvalues
+            trend = add_trend(self.y_train_, trend=self.trend, prepend=False)
+            self.trend_fit_ = OLS(endog, trend.iloc[:, 1:]).fit()
+            endog -= self.trend_fit_.fittedvalues
             return endog.rename(name)
 
     def _add_trend(self, df: pd.DataFrame) -> pd.DataFrame:
-        if self._trend == "n":
+        if self.trend == "n":
             return df
         else:
             exog = add_trend(
-                pd.concat([self._y_train, df[self._y_train.name]]),
-                trend=self._trend,
+                pd.concat([self.y_train_, df[self.y_train_.name]]),
+                trend=self.trend,
                 prepend=False,
                 has_constant="add",
             )
-            return df.apply(lambda x: x + self._trend_fit.predict(exog.iloc[-df.shape[0] :, 1:]))
+            return df.apply(lambda x: x + self.trend_fit_.predict(exog.iloc[-df.shape[0] :, 1:]))

--- a/tests/test_model_sarimax.py
+++ b/tests/test_model_sarimax.py
@@ -15,7 +15,7 @@ class TestSARIMAX(TestModelCommon):
         parameters = model.get_parameters()
 
         assert list(parameters.index) == ["sigma2"]
-        assert model._trend_fit is None
+        assert not hasattr(model, "trend_fit_")
         assert set(model.summary()[model.lbl_params].keys()) == {"sigma2"}
 
         model = SARIMAXModel(trend="c")
@@ -23,7 +23,7 @@ class TestSARIMAX(TestModelCommon):
         parameters = model.get_parameters()
 
         assert list(parameters.index) == ["sigma2"]
-        assert set(model._trend_fit.params.index.values) == {"const"}
+        assert set(model.trend_fit_.params.index.values) == {"const"}
         # trend is extracted before fitting SARIMAX, hence no 'const' among parameters
         assert set(model.summary()[model.lbl_params].keys()) == {"sigma2"}
 
@@ -32,7 +32,7 @@ class TestSARIMAX(TestModelCommon):
         parameters = model.get_parameters()
 
         assert list(parameters.index) == ["sigma2"]
-        assert set(model._trend_fit.params.index.values) == {"const", "trend"}
+        assert set(model.trend_fit_.params.index.values) == {"const", "trend"}
         assert set(model.summary()[model.lbl_params].keys()) == {"sigma2"}
 
         model = SARIMAXModel(trend="t")
@@ -40,7 +40,7 @@ class TestSARIMAX(TestModelCommon):
         parameters = model.get_parameters()
 
         assert list(parameters.index) == ["sigma2"]
-        assert set(model._trend_fit.params.index.values) == {"trend"}
+        assert set(model.trend_fit_.params.index.values) == {"trend"}
         assert set(model.summary()[model.lbl_params].keys()) == {"sigma2"}
 
         model = SARIMAXModel(trend="n")
@@ -48,7 +48,7 @@ class TestSARIMAX(TestModelCommon):
         parameters = model.get_parameters()
 
         assert list(parameters.index) == ["const", "time", "sigma2"]
-        assert model._trend_fit is None
+        assert not hasattr(model, "trend_fit_")
         assert set(model.summary()[model.lbl_params].keys()) == {"const", "time", "sigma2"}
 
     def test_model_prediction(self):


### PR DESCRIPTION
- Expose fitted attributes with trailing underscore: `x_train_`, `y_train_`, `fit_results_`.
- Expose model parameters, e.g. `endog_transform` and `exog_transform` in `H andCraftedLinearModel`.

Closes https://github.com/khrapovs/hcl-model/issues/20