### PR TITLE
Rename argument `full_weight_weeks` to `full_weight_obs` in TruncateTransformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1 (2022-02-22)
+### Changed
+- Rename argument `full_weight_weeks` to `full_weight_obs` in `hcl_model.transformers.truncate.TruncateTransformer`. Truncation is now calculated in terms of number of observations instead of datetime indexing to accommodate numpy arrays.
+
 ## 0.6.0 (2022-02-21)
 ### Changed
 - Break down `CalendarTransformer` into `sklearn` compatible transformers: `AddAutomaticSeasonalDummies`, `AddHolidayDummies`, `AddHolidayTriangles`, and `AddPeriodicSplines`.

--- a/src/hcl_model/transformers/truncate.py
+++ b/src/hcl_model/transformers/truncate.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import Union
 
+import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
 
-X_TYPE = Union[pd.Series, pd.DataFrame]
+X_TYPE = Union[np.ndarray, pd.Series, pd.DataFrame]
 
 
 class TruncateTransformer(BaseEstimator, TransformerMixin):
@@ -14,16 +15,16 @@ class TruncateTransformer(BaseEstimator, TransformerMixin):
     Leave only a specific number of past weeks.
     """
 
-    def __init__(self, full_weight_weeks: int, truncate: bool = True) -> None:
+    def __init__(self, full_weight_obs: int, truncate: bool = True) -> None:
         self.truncate = truncate
-        self.full_weight_weeks = full_weight_weeks
+        self.full_weight_obs = full_weight_obs
 
     def fit(self, X: X_TYPE, y: pd.Series = None) -> TruncateTransformer:
         return self
 
     def transform(self, X: X_TYPE) -> X_TYPE:
-        if self.truncate and self.full_weight_weeks > 0:
-            return X[X.index > X.index.max() - pd.DateOffset(weeks=self.full_weight_weeks, days=1)]
+        if self.truncate and self.full_weight_obs > 0:
+            return X[-self.full_weight_obs :]
         else:
             return X
 

--- a/tests/transformers/test_truncate.py
+++ b/tests/transformers/test_truncate.py
@@ -12,35 +12,37 @@ def test_truncate(full_weight_weeks: int) -> None:
     df = pd.DataFrame({lbl_date: pd.date_range(start="2021-01-01", end="2021-02-01"), lbl_value: range(32)})
     s = df.set_index(lbl_date)[lbl_value]
 
-    transformer = TruncateTransformer(full_weight_weeks=full_weight_weeks)
-    s_actual = transformer.transform(X=s)
     s_expected = s[s.index > s.index.max() - pd.DateOffset(weeks=full_weight_weeks, days=1)]
+    full_weight_obs = len(s_expected)
+    transformer = TruncateTransformer(full_weight_obs=full_weight_obs)
+    s_actual = transformer.transform(X=s)
     assert_series_equal(s_actual, s_expected)
     assert_series_equal(transformer.inverse_transform(X=s_actual), s_actual)
 
-    transformer = TruncateTransformer(full_weight_weeks=len(s) + 1)
+    transformer = TruncateTransformer(full_weight_obs=len(s) + 1)
     s_actual = transformer.transform(X=s)
     assert_series_equal(s_actual, s)
     assert_series_equal(transformer.inverse_transform(X=s_actual), s_actual)
 
-    transformer = TruncateTransformer(full_weight_weeks=full_weight_weeks, truncate=False)
+    transformer = TruncateTransformer(full_weight_obs=full_weight_weeks, truncate=False)
     s_actual = transformer.transform(X=s)
     assert_series_equal(s_actual, s)
     assert_series_equal(transformer.inverse_transform(X=s_actual), s_actual)
 
     data = df.set_index(lbl_date)
-    transformer = TruncateTransformer(full_weight_weeks=full_weight_weeks)
-    df_actual = transformer.transform(X=data)
     df_expected = data[data.index > data.index.max() - pd.DateOffset(weeks=full_weight_weeks, days=1)]
+    full_weight_obs = len(df_expected)
+    transformer = TruncateTransformer(full_weight_obs=full_weight_obs)
+    df_actual = transformer.transform(X=data)
     assert_frame_equal(df_actual, df_expected)
     assert_frame_equal(transformer.inverse_transform(X=df_actual), df_actual)
 
-    transformer = TruncateTransformer(full_weight_weeks=data.shape[0] + 1)
+    transformer = TruncateTransformer(full_weight_obs=data.shape[0] + 1)
     df_actual = transformer.transform(X=data)
     assert_frame_equal(df_actual, data)
     assert_frame_equal(transformer.inverse_transform(X=df_actual), df_actual)
 
-    transfomer = TruncateTransformer(full_weight_weeks=full_weight_weeks, truncate=False)
-    df_actual = transfomer.transform(X=data)
+    transformer = TruncateTransformer(full_weight_obs=full_weight_weeks, truncate=False)
+    df_actual = transformer.transform(X=data)
     assert_frame_equal(df_actual, data)
     assert_frame_equal(transformer.inverse_transform(X=df_actual), df_actual)


### PR DESCRIPTION
Rename argument `full_weight_weeks` to `full_weight_obs` in `hcl_model.transformers.truncate.TruncateTransformer`. Truncation is now calculated in terms of number of observations instead of datetime indexing to accommodate numpy arrays.